### PR TITLE
feat: add tap-to-move piece selection

### DIFF
--- a/game.js
+++ b/game.js
@@ -31,6 +31,13 @@ const winLine = document.getElementById('winline');
 const turnEl = document.getElementById('turn');
 const logEl = document.getElementById('log');
 
+svg.addEventListener('click',(ev)=>{
+  if (tapSel && !ev.target.closest('.node') && !ev.target.closest('.piece')){
+    highlight(tapSel.legal,false);
+    tapSel=null;
+  }
+});
+
 const adj = {};
 for (const [u,v] of EDGES){ (adj[u]??=new Set()).add(v); (adj[v]??=new Set()).add(u); }
 
@@ -55,11 +62,32 @@ function drawNodes(){
     t.setAttribute('x',pt.x); t.setAttribute('y',pt.y+4);
     t.setAttribute('text-anchor','middle'); t.setAttribute('fill','#555'); t.setAttribute('font-size','10');
     t.textContent=k; g.appendChild(c); g.appendChild(t); nodesG.appendChild(g);
+
+    g.addEventListener('click',()=>{
+      if (!tapSel) return;
+      const id=g.getAttribute('data-id');
+      if (tapSel.legal.has(id)){
+        pushHistory();
+        state.pieces[tapSel.who][tapSel.idx].at = id;
+        state.turn = (state.turn==='p1') ? 'p2' : 'p1';
+        log(`${tapSel.who==='p1'?'P1':'P2'}: ${tapSel.from} → ${id}`);
+        postMoveActions({side:tapSel.who,idx:tapSel.idx,from:tapSel.from,to:id});
+        highlight(tapSel.legal,false);
+        tapSel=null;
+        renderPieces();
+        if (!winner && botEnabled && state.turn==='p2') {
+          setTimeout(botMove,220);
+        }
+      } else {
+        highlight(tapSel.legal,false);
+        tapSel=null;
+      }
+    });
   }
 }
 
 /** ====================== Game State ====================== */
-let state, winner=null, dragging=null, kbNav=null;
+let state, winner=null, dragging=null, kbNav=null, tapSel=null;
 let history = []; // stack of prior states for Undo
 let botEnabled = true; // Player 2 is bot
 
@@ -80,6 +108,7 @@ function reset(){
   history = [];
   winner = null;
   dragging = null;
+  tapSel = null;
   winLine.style.display='none';
   updateUI();
   updateModeText();
@@ -243,12 +272,14 @@ function renderPieces(){
       g.addEventListener('pointerdown',(ev)=>{
         if (winner || state.turn!==who) return;
         const legal = legalTargets(state, p.at);
-        dragging={who,idx,from:p.at,x0:pt.x,y0:pt.y,legal};
+        if (tapSel){ highlight(tapSel.legal,false); tapSel=null; }
+        dragging={who,idx,from:p.at,x0:pt.x,y0:pt.y,legal,moved:false};
         highlight(legal,true);
         g.setPointerCapture(ev.pointerId);
       });
       g.addEventListener('pointermove',(ev)=>{
         if (!dragging||dragging.idx!==idx||dragging.who!==who) return;
+        dragging.moved=true;
         const q=svgPoint(ev); g.firstChild.setAttribute('cx',q.x); g.firstChild.setAttribute('cy',q.y);
       });
       g.addEventListener('pointerup',(ev)=>{
@@ -260,6 +291,24 @@ function renderPieces(){
           state.turn = (state.turn==='p1')?'p2':'p1';
           log(`${who==='p1'?'P1':'P2'}: ${dragging.from} → ${drop}`);
           postMoveActions({side:who,idx,from:dragging.from,to:drop});
+          if (tapSel){ highlight(tapSel.legal,false); tapSel=null; }
+          highlight(dragging.legal,false); dragging=null; renderPieces();
+          if (!winner && botEnabled && state.turn==='p2') {
+            setTimeout(botMove, 220); // tiny delay feels natural
+          }
+          return;
+        }
+        if (!dragging.moved){
+          if (tapSel && tapSel.who===who && tapSel.idx===idx){
+            highlight(tapSel.legal,false);
+            tapSel=null;
+          } else {
+            if (tapSel) highlight(tapSel.legal,false);
+            tapSel={who,idx,from:p.at,legal:dragging.legal};
+            highlight(tapSel.legal,true);
+          }
+          dragging=null; renderPieces();
+          return;
         }
         highlight(dragging.legal,false); dragging=null; renderPieces();
         // If bot's turn, let it move after render
@@ -271,6 +320,7 @@ function renderPieces(){
       g.addEventListener('focus',()=>{
         if (winner || state.turn!==who) return;
         const legal=legalTargets(state,p.at);
+        if (tapSel){ highlight(tapSel.legal,false); tapSel=null; }
         kbNav={who,idx,from:p.at,current:p.at,legal,el:g};
         highlight(legal,true);
       });
@@ -365,6 +415,7 @@ function undo(){
   const prev = history.pop();
   state = prev.state;
   winner = prev.winner;
+  if (tapSel){ highlight(tapSel.legal,false); tapSel=null; }
   winLine.style.display = winner ? 'block' : 'none';
   updateUI();
   renderPieces();

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     </div>
     <div class="sep"></div>
     <div class="hint">Tip: Try to control <b>X</b> early, but watch for opponent forks along two potential winning lines.<br>
-      Controls: Drag pieces or use <b>Tab</b> to focus, arrow keys to pick a destination, and <b>Enter</b> or <b>Space</b> to move.</div>
+      Controls: Tap a piece then a destination, drag pieces, or use <b>Tab</b> to focus, arrow keys to pick a destination, and <b>Enter</b> or <b>Space</b> to move.</div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- support tapping pieces to select and tapping nodes to move
- update controls text for tap-to-move

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b245e550fc8322bdf9fc408df14fe4