### PR TITLE
Make game pieces square and larger

### DIFF
--- a/game.js
+++ b/game.js
@@ -22,6 +22,7 @@ const EDGES = [
 ];
 const WINS = [['A','X','E'],['G','X','C'],['H','X','D'],['B','X','F']];
 const START = { p1:['B','C','D'], p2:['H','G','F'] };
+const PIECE_SIZE = 28;
 
 const svg = document.getElementById('board');
 const edgesG = document.getElementById('edges');
@@ -235,8 +236,12 @@ function renderPieces(){
       const g=document.createElementNS('http://www.w3.org/2000/svg','g');
       g.setAttribute('class',`piece ${cls}`); g.setAttribute('data-side',who); g.setAttribute('data-index',idx);
       g.setAttribute('tabindex','0');
-      const pt=NODES[p.at]; const c=document.createElementNS('http://www.w3.org/2000/svg','circle');
-      c.setAttribute('cx',pt.x); c.setAttribute('cy',pt.y); c.setAttribute('r',12);
+      const pt=NODES[p.at];
+      const c=document.createElementNS('http://www.w3.org/2000/svg','rect');
+      c.setAttribute('x',pt.x-PIECE_SIZE/2);
+      c.setAttribute('y',pt.y-PIECE_SIZE/2);
+      c.setAttribute('width',PIECE_SIZE);
+      c.setAttribute('height',PIECE_SIZE);
       g.appendChild(c); piecesG.appendChild(g);
 
       // Interaction only for current side and if game not over
@@ -249,7 +254,9 @@ function renderPieces(){
       });
       g.addEventListener('pointermove',(ev)=>{
         if (!dragging||dragging.idx!==idx||dragging.who!==who) return;
-        const q=svgPoint(ev); g.firstChild.setAttribute('cx',q.x); g.firstChild.setAttribute('cy',q.y);
+        const q=svgPoint(ev);
+        g.firstChild.setAttribute('x',q.x-PIECE_SIZE/2);
+        g.firstChild.setAttribute('y',q.y-PIECE_SIZE/2);
       });
       g.addEventListener('pointerup',(ev)=>{
         if (!dragging||dragging.idx!==idx||dragging.who!==who) return;
@@ -306,7 +313,8 @@ function renderPieces(){
           if (best){
             kbNav.current=best;
             const pt=NODES[best];
-            g.firstChild.setAttribute('cx',pt.x); g.firstChild.setAttribute('cy',pt.y);
+            g.firstChild.setAttribute('x',pt.x-PIECE_SIZE/2);
+            g.firstChild.setAttribute('y',pt.y-PIECE_SIZE/2);
           }
         } else if (ev.key==='Enter' || ev.key===' '){
           ev.preventDefault();

--- a/style.css
+++ b/style.css
@@ -20,11 +20,11 @@
   .node.active circle{stroke:#00e0ff;stroke-width:3}
   .edge{stroke:#e8e8e8;stroke-width:6;stroke-linecap:round;opacity:.95}
   .piece{cursor:grab}
-  .piece circle{stroke:#00000040;stroke-width:2}
-  .p1 circle{fill:var(--p1)}
-  .p2 circle{fill:var(--p2)}
+  .piece rect{stroke:#00000040;stroke-width:2}
+  .p1 rect{fill:var(--p1)}
+  .p2 rect{fill:var(--p2)}
   .piece:focus{outline:none}
-  .piece:focus circle{stroke:#00e0ff;stroke-width:3}
+  .piece:focus rect{stroke:#00e0ff;stroke-width:3}
   .winline{stroke:#8aff8a;stroke-width:10;stroke-linecap:round;opacity:.9;filter:drop-shadow(0 0 8px #77ff77)}
   .log{height:360px;overflow:auto;border-radius:10px;background:rgba(0,0,0,.18);border:1px solid rgba(255,255,255,.08);padding:10px;font-size:13px}
   .log b{color:#fff}


### PR DESCRIPTION
## Summary
- enlarge player markers and render them as squares instead of circles
- update piece movement logic for rectangular pieces

## Testing
- `node -c game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b24612a3dc83229f4ce9079f6f0b69