### PR TITLE
feat: add board flip toggle

### DIFF
--- a/game.js
+++ b/game.js
@@ -91,6 +91,7 @@ function drawNodes(){
 let state, winner=null, dragging=null, kbNav=null, tapSel=null;
 let history = []; // stack of prior states for Undo
 let botEnabled = true; // Player 2 is bot
+let flipped = false; // board orientation
 
 function clone(obj){ return JSON.parse(JSON.stringify(obj)); }
 
@@ -445,4 +446,10 @@ document.getElementById('undo').onclick = undo;
 document.getElementById('mode').onclick = () => {
   botEnabled = !botEnabled;
   updateModeText();
+};
+const flipBtn = document.getElementById('flip');
+flipBtn.onclick = () => {
+  flipped = !flipped;
+  svg.classList.toggle('flipped', flipped);
+  flipBtn.textContent = flipped ? 'Unflip Board' : 'Flip Board';
 };

--- a/index.html
+++ b/index.html
@@ -11,12 +11,13 @@
   <div class="card board-wrap">
     <div class="hud">
       <div id="turn" class="pill">Turn: Player 1 (blue)</div>
-      <div class="row">
-        <div class="pill btn" id="reset">Reset</div>
-        <div class="pill btn" id="undo">Undo</div>
-        <div class="pill" id="mode">Mode: Human vs Bot (P2)</div>
+        <div class="row">
+          <div class="pill btn" id="reset">Reset</div>
+          <div class="pill btn" id="undo">Undo</div>
+          <div class="pill" id="mode">Mode: Human vs Bot (P2)</div>
+          <div class="pill btn" id="flip">Flip Board</div>
+        </div>
       </div>
-    </div>
     <svg id="board" viewBox="0 0 300 400">
       <g id="edges"></g>
       <line id="winline" class="winline" x1="0" y1="0" x2="0" y2="0" style="display:none"/>

--- a/style.css
+++ b/style.css
@@ -13,7 +13,10 @@
   .row{display:flex;gap:8px;flex-wrap:wrap}
   .title{font-weight:800;letter-spacing:.2px}
   #board{width:100%;max-width:720px;margin:0 auto;height:auto;aspect-ratio:3/4;background:radial-gradient(ellipse at center,#0b0f23 0%,#1b1e5a 55%,#2a2e8f 100%);
-         border-radius:14px;box-shadow:0 10px 40px rgba(0,0,0,.45);border:16px solid #f2f2f2}
+         border-radius:14px;box-shadow:0 10px 40px rgba(0,0,0,.45);border:16px solid #f2f2f2;
+         transform-origin:center;}
+  #board.flipped{transform:rotate(180deg);}
+  #board.flipped text{transform:rotate(180deg);transform-box:fill-box;transform-origin:center;}
   svg text{font-weight:700;pointer-events:none}
   .node{cursor:pointer}
   .node circle{fill:#f2f2f2;stroke:#d6d6d6;stroke-width:2}


### PR DESCRIPTION
## Summary
- add Flip Board control in HUD
- style board for optional flipped orientation and upright labels
- toggle flip state in game logic and update button label

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24e03c2a48322b477cd2abd2aca76