### PR TITLE
Add animated menu screen

### DIFF
--- a/game.js
+++ b/game.js
@@ -453,3 +453,9 @@ flipBtn.onclick = () => {
   svg.classList.toggle('flipped', flipped);
   flipBtn.textContent = flipped ? 'Unflip Board' : 'Flip Board';
 };
+const menu = document.getElementById('menu');
+const startBtn = document.getElementById('start');
+startBtn.onclick = () => {
+  menu.style.display = 'none';
+  reset();
+};

--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<div id="menu" class="menu-screen">
+  <div class="logo">Cross <span class="spin">X</span></div>
+  <div id="start" class="pill btn">Start Game</div>
+</div>
 <div class="page">
   <div class="card board-wrap">
     <div class="hud">

--- a/style.css
+++ b/style.css
@@ -1,6 +1,11 @@
   :root { --bg:#0d1028; --ink:#eaeaea; --p1:#3bd1ff; --p2:#ffc04d; --hl:rgba(255,255,255,.18); }
   *{box-sizing:border-box}
   body{margin:0;background:#0b0e1e;color:#eaeaea;font-family:system-ui,Segoe UI,Roboto,Arial}
+  .menu-screen{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:40px;background:radial-gradient(ellipse at center,#0b0f23 0%,#1b1e5a 55%,#2a2e8f 100%);z-index:1000}
+  .logo{font-size:64px;font-weight:900;letter-spacing:2px}
+  .logo .spin{display:inline-block;color:var(--p2);animation:spin 4s linear infinite}
+  #start{font-size:20px;padding:12px 24px}
+  @keyframes spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
   .page{max-width:1100px;margin:24px auto;padding:0 16px;display:grid;grid-template-columns:1fr 320px;gap:16px}
   .card{background:linear-gradient(180deg,#12142f,#1a1f56);border:1px solid rgba(255,255,255,.08);border-radius:14px;box-shadow:0 10px 30px rgba(0,0,0,.35)}
   .board-wrap{padding:16px}


### PR DESCRIPTION
## Summary
- Add fullscreen menu overlay with animated logo and start button
- Style menu and spinning logo
- Wire up start button to hide menu and reset game

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b250efbe848322bfcd7076fde5ff41