### PR TITLE
Add time-based iterative deepening for bot moves

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,11 @@
             <option value="4" selected>Depth 4</option>
             <option value="6">Depth 6</option>
           </select>
+          <select id="movetime" class="pill">
+            <option value="500">0.5s</option>
+            <option value="1000" selected>1s</option>
+            <option value="2000">2s</option>
+          </select>
           <div class="pill btn" id="flip">Flip Board</div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add iterative deepening search with time limit and best-move preservation
- Introduce configurable move time option in UI
- Support timed minimax evaluation with early cutoffs

## Testing
- `node --check game.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b253e8f25483229c0d4bfaae8bdee3