### PR TITLE
Add post-game analysis feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <div class="row">
           <div class="pill btn" id="reset">Reset</div>
           <div class="pill btn" id="undo">Undo</div>
+          <div class="pill btn" id="analyze" style="display:none">Analyze</div>
           <div class="pill" id="mode">Mode: Human vs Bot (P2)</div>
           <select id="difficulty" class="pill">
             <option value="2">Depth 2</option>


### PR DESCRIPTION
## Summary
- Track moves during play and display an Analyze button after the game ends
- Added post-game analysis that compares each move to the engine's best choice and logs the difference

## Testing
- `node --check game.js`
- `npm test` (fails: no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b25274163c832290fd00c23cf905c9