### PR TITLE
Allow bot to start first

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
           <div class="pill btn" id="reset">Reset</div>
           <div class="pill btn" id="undo">Undo</div>
           <div class="pill btn" id="analyze" style="display:none">Analyze</div>
-          <div class="pill" id="mode">Mode: Human vs Bot (P2)</div>
+          <div class="pill" id="mode">Mode: Human vs Bot</div>
           <select id="difficulty" class="pill">
             <option value="2">Depth 2</option>
             <option value="4" selected>Depth 4</option>


### PR DESCRIPTION
## Summary
- Randomly assign the bot to Player 1 or Player 2 at reset and trigger an opening move when the bot starts.
- Evaluate and search from the perspective of the current bot side instead of assuming Player 2.
- Display the bot's side in the mode indicator and update post-game analysis accordingly.

## Testing
- `node -c game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b25f071150832290e12c64a7b5c924