### PR TITLE
chore: add SFX assets and dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,25 @@
+name: connex
+description: Sample Flutter project.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.5.1
+  just_audio: ^0.9.36
+  path_provider: ^2.1.3
+  hive: ^2.2.3
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/sfx/move.wav
+    - assets/sfx/win.wav


### PR DESCRIPTION
## Summary
- add move and win sound references for future SFX
- define Flutter pubspec with Riverpod, just_audio, path_provider and hive dependencies
- remove binary sound files and leave placeholder directory

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59fb71eb883229e8184e2ddefa618