### PR TITLE
Add Firebase-powered online multiplayer flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
           <div class="pill btn" id="reset">Reset</div>
           <div class="pill btn" id="undo">Undo</div>
           <div class="pill btn" id="analyze" style="display:none">Analyze</div>
-          <div class="pill" id="mode">Mode: Human vs Bot</div>
+          <div class="pill btn" id="mode">Mode: Human vs Bot</div>
           <select id="difficulty" class="pill">
             <option value="2">Depth 2</option>
             <option value="4" selected>Depth 4</option>
@@ -31,6 +31,29 @@
             <option value="2000">2s</option>
           </select>
           <div class="pill btn" id="flip">Flip Board</div>
+        </div>
+        <div class="row online-controls">
+          <div class="pill btn" id="host-session">Host Match</div>
+          <div class="pill btn" id="join-session">Join Match</div>
+          <input id="join-code" class="pill-input" type="text" placeholder="Enter room code" autocomplete="off" />
+          <div class="pill" id="room-code">Room: —</div>
+          <div class="pill status" id="connection-status" data-state="offline">Offline</div>
+          <div class="pill btn" id="leave-session">Leave</div>
+        </div>
+        <div class="config-card">
+          <div class="config-title">Firebase Config</div>
+          <div class="config-grid" id="firebase-config-form">
+            <label>apiKey<input class="pill-input" data-firebase-key="apiKey" type="text" placeholder="Required" autocomplete="off" /></label>
+            <label>authDomain<input class="pill-input" data-firebase-key="authDomain" type="text" placeholder="project.firebaseapp.com" autocomplete="off" /></label>
+            <label>projectId<input class="pill-input" data-firebase-key="projectId" type="text" placeholder="project-id" autocomplete="off" /></label>
+            <label>storageBucket<input class="pill-input" data-firebase-key="storageBucket" type="text" placeholder="project.appspot.com" autocomplete="off" /></label>
+            <label>messagingSenderId<input class="pill-input" data-firebase-key="messagingSenderId" type="text" placeholder="Sender ID" autocomplete="off" /></label>
+            <label>appId<input class="pill-input" data-firebase-key="appId" type="text" placeholder="App ID" autocomplete="off" /></label>
+          </div>
+          <div class="row config-actions">
+            <div class="pill btn" id="apply-config">Apply Config</div>
+            <div class="pill info" id="config-status">Firebase: Not configured</div>
+          </div>
         </div>
       </div>
     <svg id="board" viewBox="0 0 300 400">
@@ -65,6 +88,18 @@
   </div>
 </div>
 
+<script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore-compat.js"></script>
+<script>
+  window.FIREBASE_DEFAULT_CONFIG = {
+    apiKey: "",
+    authDomain: "",
+    projectId: "",
+    storageBucket: "",
+    messagingSenderId: "",
+    appId: ""
+  };
+</script>
 <script src="game.js" defer></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -16,7 +16,26 @@
   .btn:hover{background:rgba(255,255,255,.12)}
   .btn:active{transform:translateY(1px)}
   select.pill{color:inherit;background:rgba(255,255,255,.07);backdrop-filter:blur(6px);padding:8px 12px;border-radius:999px;border:1px solid rgba(255,255,255,.15);font-weight:600}
+  .btn.disabled{opacity:.45;pointer-events:none;cursor:default}
+  .pill-input{color:inherit;background:rgba(255,255,255,.07);backdrop-filter:blur(6px);padding:8px 12px;border-radius:999px;border:1px solid rgba(255,255,255,.15);font-weight:600;min-width:140px}
+  .pill-input:focus{outline:none;border-color:rgba(59,209,255,.7);box-shadow:0 0 0 2px rgba(59,209,255,.15)}
+  .pill-input::placeholder{color:rgba(234,234,234,.5)}
   .row{display:flex;gap:8px;flex-wrap:wrap}
+  .online-controls{margin-top:6px}
+  .online-controls .pill{display:flex;align-items:center;gap:6px}
+  .status{font-weight:700;text-transform:uppercase;letter-spacing:.6px}
+  .status[data-state="offline"]{background:rgba(255,255,255,.05);color:#f4f4f4}
+  .status[data-state="waiting"]{background:rgba(255,191,77,.18);color:#ffdf99}
+  .status[data-state="connecting"]{background:rgba(59,209,255,.18);color:#9ae7ff}
+  .status[data-state="connected"]{background:rgba(138,255,122,.18);color:#c6ffbf}
+  .status[data-state="error"]{background:rgba(255,110,110,.2);color:#ffbbbb}
+  .config-card{margin-top:12px;padding:12px;border-radius:16px;background:rgba(0,0,0,.18);border:1px solid rgba(255,255,255,.08);display:flex;flex-direction:column;gap:10px}
+  .config-title{font-weight:700;font-size:14px;letter-spacing:.4px}
+  .config-grid{display:grid;gap:8px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}
+  .config-grid label{display:flex;flex-direction:column;gap:4px;font-size:12px;text-transform:uppercase;letter-spacing:.4px;opacity:.85}
+  .config-grid label input{width:100%}
+  .config-actions{align-items:center}
+  .pill.info{background:rgba(255,255,255,.05);font-weight:500}
   .title{font-weight:800;letter-spacing:.2px}
   #board{width:100%;max-width:720px;margin:0 auto;height:auto;aspect-ratio:3/4;background:radial-gradient(ellipse at center,#0b0f23 0%,#1b1e5a 55%,#2a2e8f 100%);
          border-radius:14px;box-shadow:0 10px 40px rgba(0,0,0,.45);border:16px solid #f2f2f2;


### PR DESCRIPTION
## Summary
- add HUD controls for hosting or joining matches, connection status, and Firebase config inputs
- implement Firebase-backed WebRTC signaling helpers and peer data channel messaging
- synchronize game moves between peers while disabling bot/undo/reset during online sessions

## Testing
- not run (environment only)

------
https://chatgpt.com/codex/tasks/task_e_68d63423c250832282cae47faccb2893